### PR TITLE
Feat: Post, Comment, Like Entity 추가

### DIFF
--- a/src/main/java/fastcampus/feed/post/domain/Post.java
+++ b/src/main/java/fastcampus/feed/post/domain/Post.java
@@ -3,9 +3,13 @@ package fastcampus.feed.post.domain;
 import fastcampus.feed.common.domain.PositiveIntegerCount;
 import fastcampus.feed.post.domain.content.PostContent;
 import fastcampus.feed.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class Post {
 
     private final Long id;

--- a/src/main/java/fastcampus/feed/post/domain/comment/Comment.java
+++ b/src/main/java/fastcampus/feed/post/domain/comment/Comment.java
@@ -4,9 +4,13 @@ import fastcampus.feed.common.domain.PositiveIntegerCount;
 import fastcampus.feed.post.domain.Post;
 import fastcampus.feed.post.domain.content.Content;
 import fastcampus.feed.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class Comment {
 
     private final Long id;

--- a/src/main/java/fastcampus/feed/post/domain/content/PostContent.java
+++ b/src/main/java/fastcampus/feed/post/domain/content/PostContent.java
@@ -2,6 +2,7 @@ package fastcampus.feed.post.domain.content;
 
 import lombok.Getter;
 
+@Getter
 public class PostContent extends Content {
     private static final int MAX_LENGTH = 500;
     private static final int MIN_LENGTH = 5;

--- a/src/main/java/fastcampus/feed/post/repository/entity/comment/CommentEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/comment/CommentEntity.java
@@ -1,0 +1,62 @@
+package fastcampus.feed.post.repository.entity.comment;
+
+
+import fastcampus.feed.common.domain.PositiveIntegerCount;
+import fastcampus.feed.common.repository.entity.TimeBaseEntity;
+import fastcampus.feed.post.domain.comment.Comment;
+import fastcampus.feed.post.domain.content.CommentContent;
+import fastcampus.feed.post.repository.entity.post.PostEntity;
+import fastcampus.feed.user.repository.entity.UserEntity;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "comment")
+@NoArgsConstructor
+@Entity
+public class CommentEntity extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private UserEntity author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private PostEntity post;
+
+    private String content;
+    private int likeCount;
+
+
+    public CommentEntity(Comment comment) {
+        this.id = comment.getId();
+        this.author = new UserEntity(comment.getAuthor());
+        this.post = new PostEntity(comment.getPost());
+        this.content = comment.getContent().getContentText();
+        this.likeCount = comment.getLikeCount().getCount();
+    }
+
+    public Comment toComment() {
+        return Comment.builder()
+                .id(id)
+                .author(author.toUser())
+                .post(post.toPost())
+                .content(new CommentContent(content))
+                .likeCount(new PositiveIntegerCount(likeCount))
+                .build();
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/entity/like/LikeEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/like/LikeEntity.java
@@ -1,0 +1,30 @@
+package fastcampus.feed.post.repository.entity.like;
+
+import fastcampus.feed.common.repository.entity.TimeBaseEntity;
+import fastcampus.feed.post.domain.Post;
+import fastcampus.feed.post.domain.comment.Comment;
+import fastcampus.feed.user.domain.User;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "likes")
+public class LikeEntity extends TimeBaseEntity {
+
+    @EmbeddedId
+    private LikeIdEntity likeIdEntity;
+
+
+    public LikeEntity(Post post, User user){
+        this.likeIdEntity = new LikeIdEntity(post.getId(), user.getId(), LikeTarget.POST);
+    }
+
+    public LikeEntity(Comment comment, User user){
+        this.likeIdEntity = new LikeIdEntity(comment.getId(), user.getId(), LikeTarget.COMMENT);
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/entity/like/LikeIdEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/like/LikeIdEntity.java
@@ -1,0 +1,21 @@
+package fastcampus.feed.post.repository.entity.like;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+@AllArgsConstructor
+public class LikeIdEntity {
+
+    private Long targetId;
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private LikeTarget target;
+}

--- a/src/main/java/fastcampus/feed/post/repository/entity/like/LikeTarget.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/like/LikeTarget.java
@@ -1,0 +1,5 @@
+package fastcampus.feed.post.repository.entity.like;
+
+public enum LikeTarget {
+    POST, COMMENT
+}

--- a/src/main/java/fastcampus/feed/post/repository/entity/post/PostEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/post/PostEntity.java
@@ -1,0 +1,61 @@
+package fastcampus.feed.post.repository.entity.post;
+
+import fastcampus.feed.common.domain.PositiveIntegerCount;
+import fastcampus.feed.common.repository.entity.TimeBaseEntity;
+import fastcampus.feed.post.domain.Post;
+import fastcampus.feed.post.domain.PostPublishState;
+import fastcampus.feed.post.domain.content.PostContent;
+import fastcampus.feed.user.repository.entity.UserEntity;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post")
+@Getter
+@NoArgsConstructor
+public class PostEntity extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id",foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private UserEntity author;
+
+    private String content;
+
+    @Convert(converter = PostPublishStateConverter.class)
+    private PostPublishState postPublishState;
+
+    private Integer likeCount;
+
+    public PostEntity(Post post){
+        this.id = post.getId();
+        this.author = new UserEntity(post.getAuthor());
+        this.content = post.getPostContent().getContentText();
+        this.postPublishState = post.getPostPublishState();
+        this.likeCount = post.getLikeCount().getCount();
+    }
+
+    public Post toPost(){
+        return Post.builder()
+                .id(id)
+                .author(author.toUser())
+                .postContent(new PostContent(content))
+                .postPublishState(postPublishState)
+                .likeCount(new PositiveIntegerCount(likeCount))
+                .build();
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/entity/post/PostPublishStateConverter.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/post/PostPublishStateConverter.java
@@ -1,0 +1,21 @@
+package fastcampus.feed.post.repository.entity.post;
+
+import fastcampus.feed.post.domain.PostPublishState;
+import jakarta.persistence.AttributeConverter;
+
+public class PostPublishStateConverter implements AttributeConverter<PostPublishState, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PostPublishState attribute) {
+        return attribute.name();
+    }
+
+    @Override
+    public PostPublishState convertToEntityAttribute(String dbData) {
+        return PostPublishState.valueOf(dbData);
+    }
+
+
+
+
+}


### PR DESCRIPTION
LikeEntity를 구분하는 식별자 Id Class 추가 -> EmbeddedId 방식 사용

Like 대상이 Post인지 Comment인지 구별하기 위한 likeTarget Class 생성

Enum 값을 변환해주는 Converter Class 생성(AttributeConveter 인터페이스 구현)
- @Enumberated 애노테이션 사용 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게시물, 댓글, 좋아요 엔티티 추가
	- 게시물 및 댓글에 대한 Lombok 어노테이션 도입으로 객체 생성 유연성 향상

- **개선 사항**
	- 데이터베이스 엔티티 매핑을 위한 JPA 어노테이션 추가
	- 게시물 및 댓글의 속성 접근성 개선
	- 좋아요 대상(게시물/댓글) 지원 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->