### PR TITLE
Feat: Post, Comment, Like Controller 레이어 구현

### DIFF
--- a/src/main/java/fastcampus/feed/post/controller/CommentController.java
+++ b/src/main/java/fastcampus/feed/post/controller/CommentController.java
@@ -1,0 +1,40 @@
+package fastcampus.feed.post.controller;
+
+import fastcampus.feed.common.controller.Response;
+import fastcampus.feed.post.service.CommentService;
+import fastcampus.feed.post.service.dto.CreateCommentRequestDto;
+import fastcampus.feed.post.service.dto.LikeCommentRequestDto;
+import fastcampus.feed.post.service.dto.UpdateCommentRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public Response<Long> createComment(@RequestBody CreateCommentRequestDto dto){
+        return Response.ok(commentService.createComment(dto).getId());
+    }
+
+    @PatchMapping("/{commentId}")
+    public Response<Void> updateComment(@PathVariable Long commentId, @RequestBody UpdateCommentRequestDto dto){
+        commentService.updateComment(commentId, dto);
+        return Response.ok(null);
+    }
+
+    @PostMapping("/{commentId}/like")
+    public Response<Void> likeComment(@PathVariable Long commentId, @RequestBody LikeCommentRequestDto dto){
+        commentService.likeComment(commentId, dto);
+        return Response.ok(null);
+    }
+
+}

--- a/src/main/java/fastcampus/feed/post/controller/PostController.java
+++ b/src/main/java/fastcampus/feed/post/controller/PostController.java
@@ -1,0 +1,47 @@
+package fastcampus.feed.post.controller;
+
+import fastcampus.feed.common.controller.Response;
+import fastcampus.feed.post.service.PostService;
+import fastcampus.feed.post.service.dto.CreatePostRequestDto;
+import fastcampus.feed.post.service.dto.LikePostRequestDto;
+import fastcampus.feed.post.service.dto.UpdatePostRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/post")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public Response<Long> createPost(@RequestBody CreatePostRequestDto dto){
+        return Response.ok(postService.createPost(dto).getId());
+    }
+
+    @PatchMapping("/{postId}")
+    public Response<Void> updatePost(@PathVariable Long postId, @RequestBody UpdatePostRequestDto dto){
+        postService.updatePost(postId,dto);
+        return Response.ok(null);
+    }
+
+    @PostMapping("/{postId}/like")
+    public Response<Void> likePost(@PathVariable Long postId,@RequestBody LikePostRequestDto dto){
+        postService.likePost(postId, dto);
+        return Response.ok(null);
+    }
+
+    @PostMapping("/{postId}/unlike")
+    public Response<Void> unlikePost(@PathVariable Long postId, @RequestBody LikePostRequestDto dto){
+        postService.unlikePost(postId, dto);
+        return Response.ok(null);
+    }
+
+
+}

--- a/src/main/java/fastcampus/feed/post/repository/CommentRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/CommentRepositoryImpl.java
@@ -1,0 +1,26 @@
+package fastcampus.feed.post.repository;
+
+import fastcampus.feed.post.domain.comment.Comment;
+import fastcampus.feed.post.repository.entity.comment.CommentEntity;
+import fastcampus.feed.post.repository.interfaces.CommentRepository;
+import fastcampus.feed.post.repository.jpa.JpaCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepository {
+
+    private final JpaCommentRepository jpaCommentRepository;
+
+    @Override
+    public Comment save(Comment comment) {
+        CommentEntity commentEntity = new CommentEntity(comment);
+        return jpaCommentRepository.save(commentEntity).toComment();
+    }
+
+    @Override
+    public Comment findById(Long id) {
+        return jpaCommentRepository.findById(id).orElseThrow(IllegalArgumentException::new).toComment();
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/LikeRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/LikeRepositoryImpl.java
@@ -1,0 +1,71 @@
+package fastcampus.feed.post.repository;
+
+import fastcampus.feed.post.domain.Post;
+import fastcampus.feed.post.domain.comment.Comment;
+import fastcampus.feed.post.repository.entity.comment.CommentEntity;
+import fastcampus.feed.post.repository.entity.like.LikeEntity;
+import fastcampus.feed.post.repository.entity.like.LikeIdEntity;
+import fastcampus.feed.post.repository.entity.like.LikeTarget;
+import fastcampus.feed.post.repository.entity.post.PostEntity;
+import fastcampus.feed.post.repository.interfaces.LikeRepository;
+import fastcampus.feed.post.repository.jpa.JpaCommentRepository;
+import fastcampus.feed.post.repository.jpa.JpaLikeRepository;
+import fastcampus.feed.post.repository.jpa.JpaPostRepository;
+import fastcampus.feed.user.domain.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeRepository {
+
+    @PersistenceContext
+    private EntityManager em; //likeEntity는 항상 select 쿼리를 보낸다. 이런 무의미한 조회 쿼리를 줄이기 위해 바로 persist를 적용
+
+    private final JpaLikeRepository jpaLikeRepository;
+    private final JpaPostRepository jpaPostRepository;
+    private final JpaCommentRepository jpaCommentRepository;
+
+    @Override
+    public boolean isAlreadyLiked(User user, Post post) {
+        LikeIdEntity likeIdEntity = new LikeIdEntity(user.getId(), post.getId(), LikeTarget.POST);
+        return jpaLikeRepository.existsById(likeIdEntity);
+    }
+
+    @Override
+    public void save(User user, Post post) {
+        LikeEntity likeEntity = new LikeEntity(post, user);
+        em.persist(likeEntity);
+        //jpaLikeRepository.save(likeEntity); //이렇게 하면 select 쿼리가 먼저 나가서 무의미한 조회 쿼리가 발생
+        jpaPostRepository.save(new PostEntity(post));
+    }
+
+    @Override
+    public void delete(User user, Post post) {
+        LikeIdEntity likeIdEntity = new LikeIdEntity(user.getId(), post.getId(), LikeTarget.POST);
+        jpaPostRepository.save(new PostEntity(post));
+        jpaLikeRepository.deleteById(likeIdEntity);
+    }
+
+    @Override
+    public boolean isAlreadyLiked(User user, Comment comment) {
+        LikeIdEntity likeIdEntity = new LikeIdEntity(user.getId(), comment.getId(), LikeTarget.COMMENT);
+        return jpaLikeRepository.existsById(likeIdEntity);
+    }
+
+    @Override
+    public void save(User user, Comment comment) {
+        LikeEntity likeEntity = new LikeEntity(comment, user);
+        em.persist(likeEntity);
+        jpaCommentRepository.save(new CommentEntity(comment));
+    }
+
+    @Override
+    public void delete(User user, Comment comment) {
+        LikeIdEntity likeIdEntity = new LikeIdEntity(user.getId(), comment.getId(), LikeTarget.COMMENT);
+        jpaCommentRepository.save(new CommentEntity(comment));
+        jpaLikeRepository.deleteById(likeIdEntity);
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,27 @@
+package fastcampus.feed.post.repository;
+
+import fastcampus.feed.post.domain.Post;
+import fastcampus.feed.post.repository.entity.post.PostEntity;
+import fastcampus.feed.post.repository.interfaces.PostRepository;
+import fastcampus.feed.post.repository.jpa.JpaPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepository {
+
+    private final JpaPostRepository jpaPostRepository;
+
+
+    @Override
+    public Post save(Post post) {
+        PostEntity postEntity = new PostEntity(post);
+        return jpaPostRepository.save(postEntity).toPost();
+    }
+
+    @Override
+    public Post findById(Long id) {
+        return jpaPostRepository.findById(id).orElseThrow(IllegalArgumentException::new).toPost();
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/entity/post/PostEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/post/PostEntity.java
@@ -19,11 +19,13 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Table(name = "post")
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 public class PostEntity extends TimeBaseEntity {
 
     @Id

--- a/src/main/java/fastcampus/feed/post/repository/jpa/JpaCommentRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/jpa/JpaCommentRepository.java
@@ -1,0 +1,8 @@
+package fastcampus.feed.post.repository.jpa;
+
+import fastcampus.feed.post.repository.entity.comment.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCommentRepository extends JpaRepository<CommentEntity, Long> {
+
+}

--- a/src/main/java/fastcampus/feed/post/repository/jpa/JpaLikeRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/jpa/JpaLikeRepository.java
@@ -1,0 +1,9 @@
+package fastcampus.feed.post.repository.jpa;
+
+import fastcampus.feed.post.repository.entity.like.LikeEntity;
+import fastcampus.feed.post.repository.entity.like.LikeIdEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaLikeRepository extends JpaRepository<LikeEntity, LikeIdEntity> {
+
+}

--- a/src/main/java/fastcampus/feed/post/repository/jpa/JpaPostRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/jpa/JpaPostRepository.java
@@ -1,0 +1,8 @@
+package fastcampus.feed.post.repository.jpa;
+
+import fastcampus.feed.post.repository.entity.post.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPostRepository extends JpaRepository<PostEntity, Long> {
+
+}

--- a/src/main/java/fastcampus/feed/post/service/CommentService.java
+++ b/src/main/java/fastcampus/feed/post/service/CommentService.java
@@ -5,13 +5,15 @@ import fastcampus.feed.post.domain.comment.Comment;
 import fastcampus.feed.post.domain.content.CommentContent;
 import fastcampus.feed.post.repository.interfaces.CommentRepository;
 import fastcampus.feed.post.repository.interfaces.LikeRepository;
-import fastcampus.feed.post.repository.interfaces.PostRepository;
 import fastcampus.feed.post.service.dto.CreateCommentRequestDto;
 import fastcampus.feed.post.service.dto.LikeCommentRequestDto;
 import fastcampus.feed.post.service.dto.UpdateCommentRequestDto;
 import fastcampus.feed.user.domain.User;
 import fastcampus.feed.user.service.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Service
 public class CommentService {
 
     private final UserService userService;
@@ -26,7 +28,7 @@ public class CommentService {
         this.likeRepository = likeRepository;
         this.postService = postService;
     }
-
+    @Transactional
     public Comment createComment(CreateCommentRequestDto dto) {
         Post post = postService.getPost(dto.postId());
         User user = userService.getUser(dto.userId());
@@ -40,17 +42,18 @@ public class CommentService {
         return commentRepository.findById(commentId);
     }
 
-    public Comment updateComment(UpdateCommentRequestDto dto){
-        Comment comment = getComment(dto.commentId());
+    @Transactional
+    public Comment updateComment(Long commentId, UpdateCommentRequestDto dto){
+        Comment comment = getComment(commentId);
         User user = userService.getUser(dto.userId());
 
         comment.updateComment(user, dto.content());
 
         return commentRepository.save(comment);
     }
-
-    public void likeComment(LikeCommentRequestDto dto) {
-        Comment comment = getComment(dto.commentId());
+    @Transactional
+    public void likeComment(Long commentId, LikeCommentRequestDto dto) {
+        Comment comment = getComment(commentId);
         User user = userService.getUser(dto.userId());
 
         if (likeRepository.isAlreadyLiked(user, comment)) {
@@ -60,9 +63,9 @@ public class CommentService {
         comment.like(user);
         likeRepository.save(user, comment);
     }
-
-    public void unlikeComment(LikeCommentRequestDto dto) {
-        Comment comment = getComment(dto.commentId());
+    @Transactional
+    public void unlikeComment(Long commentId, LikeCommentRequestDto dto) {
+        Comment comment = getComment(commentId);
         User user = userService.getUser(dto.userId());
 
         if (likeRepository.isAlreadyLiked(user, comment)) {

--- a/src/main/java/fastcampus/feed/post/service/PostService.java
+++ b/src/main/java/fastcampus/feed/post/service/PostService.java
@@ -9,20 +9,18 @@ import fastcampus.feed.post.service.dto.CreatePostRequestDto;
 import fastcampus.feed.post.service.dto.UpdatePostRequestDto;
 import fastcampus.feed.user.domain.User;
 import fastcampus.feed.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Service
+@RequiredArgsConstructor
 public class PostService {
 
     private final PostRepository postRepository;
     private final UserService userService;
-    private LikeRepository likeRepository;
+    private final LikeRepository likeRepository;
 
-    public PostService(UserService userService, PostRepository postRepository,
-            LikeRepository likeRepository) {
-        this.postRepository = postRepository;
-        this.userService = userService;
-        this.likeRepository = likeRepository;
-    }
 
     @Transactional
     public Post getPost(Long id){
@@ -41,17 +39,17 @@ public class PostService {
     }
 
     @Transactional
-    public void updatePost(UpdatePostRequestDto dto){
-        Post post = getPost(dto.postId());
+    public void updatePost(Long postId, UpdatePostRequestDto dto){
+        Post post = getPost(postId);
         User user = userService.getUser(dto.userId());
         post.updatePost(user, dto.content(), dto.publishState());
         postRepository.save(post);
     }
 
     @Transactional
-    public void likePost(LikePostRequestDto dto) {
+    public void likePost(Long postId, LikePostRequestDto dto) {
         User user = userService.getUser(dto.userId());
-        Post post = getPost(dto.postId());
+        Post post = getPost(postId);
 
         if (likeRepository.isAlreadyLiked(user, post)) {
             return;
@@ -62,9 +60,9 @@ public class PostService {
     }
 
     @Transactional
-    public void unlikePost(LikePostRequestDto dto) {
+    public void unlikePost(Long postId, LikePostRequestDto dto) {
         User user = userService.getUser(dto.userId());
-        Post post = getPost(dto.postId());
+        Post post = getPost(postId);
 
         if (likeRepository.isAlreadyLiked(user, post)) {
             likeRepository.delete(user, post);

--- a/src/main/java/fastcampus/feed/post/service/dto/LikeCommentRequestDto.java
+++ b/src/main/java/fastcampus/feed/post/service/dto/LikeCommentRequestDto.java
@@ -1,4 +1,4 @@
 package fastcampus.feed.post.service.dto;
 
-public record LikeCommentRequestDto(Long userId, Long commentId) {
+public record LikeCommentRequestDto(Long userId) {
 }

--- a/src/main/java/fastcampus/feed/post/service/dto/LikePostRequestDto.java
+++ b/src/main/java/fastcampus/feed/post/service/dto/LikePostRequestDto.java
@@ -1,5 +1,5 @@
 package fastcampus.feed.post.service.dto;
 
-public record LikePostRequestDto(Long userId, Long postId) {
+public record LikePostRequestDto(Long userId) {
 
 }

--- a/src/main/java/fastcampus/feed/post/service/dto/UpdateCommentRequestDto.java
+++ b/src/main/java/fastcampus/feed/post/service/dto/UpdateCommentRequestDto.java
@@ -1,5 +1,5 @@
 package fastcampus.feed.post.service.dto;
 
-public record UpdateCommentRequestDto(Long userId, Long commentId, String content) {
+public record UpdateCommentRequestDto(Long userId, String content) {
 
 }

--- a/src/main/java/fastcampus/feed/post/service/dto/UpdatePostRequestDto.java
+++ b/src/main/java/fastcampus/feed/post/service/dto/UpdatePostRequestDto.java
@@ -2,6 +2,6 @@ package fastcampus.feed.post.service.dto;
 
 import fastcampus.feed.post.domain.PostPublishState;
 
-public record UpdatePostRequestDto(Long userId, Long postId, String content, PostPublishState publishState) {
+public record UpdatePostRequestDto(Long userId,String content, PostPublishState publishState) {
 
 }

--- a/src/test/java/fastcampus/feed/fake/FakeObjectFactory.java
+++ b/src/test/java/fastcampus/feed/fake/FakeObjectFactory.java
@@ -29,7 +29,7 @@ public class FakeObjectFactory {
     private static final UserService userService = new UserService(fakeUserRepository);
     private static final FollowService followService = new FollowService(
             fakeUserRelationRepository, userService);
-    private static final PostService postService = new PostService(userService, fakePostRepository,
+    private static final PostService postService = new PostService(fakePostRepository, userService,
             fakeLikeRepository);
     private static final CommentService commentService = new CommentService(fakeCommentRepository,
             userService, fakeLikeRepository, postService);

--- a/src/test/java/fastcampus/feed/post/service/CommentServiceTest.java
+++ b/src/test/java/fastcampus/feed/post/service/CommentServiceTest.java
@@ -65,9 +65,9 @@ class CommentServiceTest {
         Comment savedComment = commentService.createComment(commentDto);
 
         //when
-        Comment updatedComment = commentService.updateComment(
-                new UpdateCommentRequestDto(user1.getId(), savedComment.getId(),
-                        "updatedCommentContent"));
+        Comment updatedComment = commentService.updateComment(savedComment.getId(),
+                new UpdateCommentRequestDto(user1.getId(), "updatedCommentContent"));
+
         //then
         assertEquals(updatedComment.getContent().getContentText(), "updatedCommentContent");
     }
@@ -76,10 +76,9 @@ class CommentServiceTest {
     void like() throws Exception {
         //given
         Comment savedComment = commentService.createComment(commentDto);
-        LikeCommentRequestDto likeDto = new LikeCommentRequestDto(user2.getId(),
-                savedComment.getId());
+        LikeCommentRequestDto likeDto = new LikeCommentRequestDto(user2.getId());
         //when
-        commentService.likeComment(likeDto);
+        commentService.likeComment(savedComment.getId(), likeDto);
 
         //then
         assertEquals(savedComment.getLikeCount().getCount(), 1);
@@ -89,12 +88,12 @@ class CommentServiceTest {
     void like_already_Ex() throws Exception {
         //given
         Comment savedComment = commentService.createComment(commentDto);
-        LikeCommentRequestDto likeDto = new LikeCommentRequestDto(user2.getId(),
-                savedComment.getId());
+        LikeCommentRequestDto likeDto = new LikeCommentRequestDto(user2.getId()
+        );
 
-        commentService.likeComment(likeDto);
+        commentService.likeComment(savedComment.getId(), likeDto);
         //when
-        commentService.likeComment(likeDto);
+        commentService.likeComment(savedComment.getId(), likeDto);
         //then
         assertEquals(savedComment.getLikeCount().getCount(), 1);
 
@@ -105,17 +104,16 @@ class CommentServiceTest {
     void unlike() throws Exception {
         //given
         Comment savedComment = commentService.createComment(commentDto);
-        LikeCommentRequestDto likeDto = new LikeCommentRequestDto(user2.getId(),
-                savedComment.getId());
-        commentService.likeComment(likeDto);
+        LikeCommentRequestDto likeDto = new LikeCommentRequestDto(user2.getId());
+        commentService.likeComment(savedComment.getId(),likeDto);
 
         //when
-        commentService.unlikeComment(likeDto);
+        commentService.unlikeComment(savedComment.getId(),likeDto);
 
         //then
         assertEquals(savedComment.getLikeCount().getCount(), 0);
 
-        commentService.unlikeComment(likeDto);
+        commentService.unlikeComment(savedComment.getId(), likeDto);
         assertEquals(savedComment.getLikeCount().getCount(), 0);
     }
 

--- a/src/test/java/fastcampus/feed/post/service/PostServiceTest.java
+++ b/src/test/java/fastcampus/feed/post/service/PostServiceTest.java
@@ -60,9 +60,9 @@ class PostServiceTest {
     @Test
     void updatePost() throws Exception {
         //given
-        UpdatePostRequestDto updateDto = new UpdatePostRequestDto(user1.getId(), post1.getId(), "updatedContent",
+        UpdatePostRequestDto updateDto = new UpdatePostRequestDto(user1.getId(), "updatedContent",
                 PostPublishState.PRIVATE);
-        postService.updatePost(updateDto);
+        postService.updatePost(post1.getId(),updateDto);
 
         //when
         Post updatedPost = postService.getPost(post1.getId());
@@ -76,9 +76,9 @@ class PostServiceTest {
     @Test
     void likePost() throws Exception {
         //given
-        LikePostRequestDto likeDto = new LikePostRequestDto(user2.getId(), post1.getId());
+        LikePostRequestDto likeDto = new LikePostRequestDto(user2.getId());
         //when
-        postService.likePost(likeDto);
+        postService.likePost(post1.getId(), likeDto);
         //then
         assertEquals(post1.getLikeCount().getCount(), 1);
 
@@ -86,9 +86,9 @@ class PostServiceTest {
     @Test
     void like_already_post() throws Exception {
         //given
-        LikePostRequestDto likeDto = new LikePostRequestDto(user2.getId(), post1.getId());
+        LikePostRequestDto likeDto = new LikePostRequestDto(user2.getId());
         //when
-        postService.likePost(likeDto);
+        postService.likePost(post1.getId(), likeDto);
         //then
         assertEquals(post1.getLikeCount().getCount(), 1);
     }
@@ -96,15 +96,15 @@ class PostServiceTest {
     @Test
     void unlike() throws Exception {
         //given
-        LikePostRequestDto likeDto = new LikePostRequestDto(user2.getId(), post1.getId());
-        postService.likePost(likeDto);
+        LikePostRequestDto likeDto = new LikePostRequestDto(user2.getId());
+        postService.likePost(post1.getId(), likeDto);
 
         //when
-        postService.unlikePost(likeDto);
+        postService.unlikePost(post1.getId(), likeDto);
         //then
         assertEquals(post1.getLikeCount().getCount(), 0);
 
-        postService.unlikePost(likeDto);
+        postService.unlikePost(post1.getId(), likeDto);
         assertEquals(post1.getLikeCount().getCount(), 0);
 
     }


### PR DESCRIPTION
1. 트랜잭션 위치
2. EntityManager 직접 주입으로 항상 발생하는 likeEntity 조회 쿼리 생략하기
3. URL로 domain의 ID를 전달받고 DTO에 이를 제거 -> 테스트 코드 수정
4. 각각의 컨트롤러 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 포스트 및 댓글에 대한 생성, 업데이트, 좋아요 기능 추가
  - 포스트와 댓글에 대한 REST API 엔드포인트 구현

- **개선 사항**
  - 서비스 및 컨트롤러 로직 최적화
  - 데이터 전송 객체(DTO) 구조 간소화
  - 트랜잭션 관리 개선

- **버그 수정**
  - 좋아요 및 포스트/댓글 업데이트 프로세스의 일관성 향상

- **기술적 변경**
  - Spring Data JPA 리포지토리 추가
  - 동적 엔티티 업데이트 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->