### PR TITLE
Feat: Post Feed 관련 조회 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//p6spy
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/fastcampus/feed/post/controller/FeedController.java
+++ b/src/main/java/fastcampus/feed/post/controller/FeedController.java
@@ -1,0 +1,25 @@
+package fastcampus.feed.post.controller;
+
+import fastcampus.feed.common.controller.Response;
+import fastcampus.feed.post.controller.dto.GetPostContentResponseDto;
+import fastcampus.feed.post.repository.post_queue.UserPostQueueQueryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final UserPostQueueQueryRepository queueQueryRepository;
+
+    @GetMapping("/{userId}")
+    public Response<List<GetPostContentResponseDto>> getPostFeed(@PathVariable Long userId, Long lastPostId) {
+        List<GetPostContentResponseDto> result = queueQueryRepository.getContentResponse(userId, lastPostId);
+        return Response.ok(result);
+    }
+}

--- a/src/main/java/fastcampus/feed/post/controller/dto/GetContentResponseDto.java
+++ b/src/main/java/fastcampus/feed/post/controller/dto/GetContentResponseDto.java
@@ -1,0 +1,26 @@
+package fastcampus.feed.post.controller.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetContentResponseDto {
+
+    private Long id;
+    private String content;
+    private Long userId;
+    private String userName;
+    private String profileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer likeCount;
+    private boolean isLikedByMe;
+}

--- a/src/main/java/fastcampus/feed/post/controller/dto/GetPostContentResponseDto.java
+++ b/src/main/java/fastcampus/feed/post/controller/dto/GetPostContentResponseDto.java
@@ -1,0 +1,17 @@
+package fastcampus.feed.post.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetPostContentResponseDto extends GetContentResponseDto{
+
+    private Integer commentCount;
+}

--- a/src/main/java/fastcampus/feed/post/repository/CommentRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/CommentRepositoryImpl.java
@@ -4,6 +4,7 @@ import fastcampus.feed.post.domain.comment.Comment;
 import fastcampus.feed.post.repository.entity.comment.CommentEntity;
 import fastcampus.feed.post.repository.interfaces.CommentRepository;
 import fastcampus.feed.post.repository.jpa.JpaCommentRepository;
+import fastcampus.feed.post.repository.jpa.JpaPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +13,11 @@ import org.springframework.stereotype.Repository;
 public class CommentRepositoryImpl implements CommentRepository {
 
     private final JpaCommentRepository jpaCommentRepository;
+    private final JpaPostRepository jpaPostRepository;
 
     @Override
     public Comment save(Comment comment) {
+        jpaPostRepository.findById(comment.getPost().getId()).orElseThrow(IllegalArgumentException::new).increaseCommentCount();
         CommentEntity commentEntity = new CommentEntity(comment);
         return jpaCommentRepository.save(commentEntity).toComment();
     }

--- a/src/main/java/fastcampus/feed/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/PostRepositoryImpl.java
@@ -4,6 +4,7 @@ import fastcampus.feed.post.domain.Post;
 import fastcampus.feed.post.repository.entity.post.PostEntity;
 import fastcampus.feed.post.repository.interfaces.PostRepository;
 import fastcampus.feed.post.repository.jpa.JpaPostRepository;
+import fastcampus.feed.post.repository.post_queue.UserPostQueueCommandRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,11 +13,12 @@ import org.springframework.stereotype.Repository;
 public class PostRepositoryImpl implements PostRepository {
 
     private final JpaPostRepository jpaPostRepository;
-
+    private final UserPostQueueCommandRepository userPostQueueCommandRepository;
 
     @Override
     public Post save(Post post) {
         PostEntity postEntity = new PostEntity(post);
+        userPostQueueCommandRepository.publishPost(postEntity);
         return jpaPostRepository.save(postEntity).toPost();
     }
 

--- a/src/main/java/fastcampus/feed/post/repository/entity/like/LikeIdEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/like/LikeIdEntity.java
@@ -17,5 +17,5 @@ public class LikeIdEntity {
     private Long userId;
 
     @Enumerated(EnumType.STRING)
-    private LikeTarget target;
+    private LikeTarget targetType;
 }

--- a/src/main/java/fastcampus/feed/post/repository/entity/post/PostEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/post/PostEntity.java
@@ -19,6 +19,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
@@ -43,6 +44,9 @@ public class PostEntity extends TimeBaseEntity {
 
     private Integer likeCount;
 
+    @ColumnDefault("0")
+    private int commentCount;
+
     public PostEntity(Post post){
         this.id = post.getId();
         this.author = new UserEntity(post.getAuthor());
@@ -59,5 +63,9 @@ public class PostEntity extends TimeBaseEntity {
                 .postPublishState(postPublishState)
                 .likeCount(new PositiveIntegerCount(likeCount))
                 .build();
+    }
+
+    public void increaseCommentCount(){
+        this.commentCount++;
     }
 }

--- a/src/main/java/fastcampus/feed/post/repository/entity/post/UserPostQueueEntity.java
+++ b/src/main/java/fastcampus/feed/post/repository/entity/post/UserPostQueueEntity.java
@@ -1,0 +1,33 @@
+package fastcampus.feed.post.repository.entity.post;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_post_queue")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPostQueueEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long postId;
+    private Long authorId;
+
+    public UserPostQueueEntity(Long userId, Long postId, Long authorId){
+        this.userId = userId;
+        this.postId = postId;
+        this.authorId = authorId;
+    }
+
+}

--- a/src/main/java/fastcampus/feed/post/repository/jpa/JpaPostRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/jpa/JpaPostRepository.java
@@ -1,8 +1,12 @@
 package fastcampus.feed.post.repository.jpa;
 
 import fastcampus.feed.post.repository.entity.post.PostEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaPostRepository extends JpaRepository<PostEntity, Long> {
 
+    @Query("SELECT p.id FROM PostEntity p WHERE p.author.id = :authorId")
+    List<Long> findAllPostIdsByAuthorId(Long authorId);
 }

--- a/src/main/java/fastcampus/feed/post/repository/jpa/JpaUserPostQueueRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/jpa/JpaUserPostQueueRepository.java
@@ -1,0 +1,9 @@
+package fastcampus.feed.post.repository.jpa;
+
+import fastcampus.feed.post.repository.entity.post.UserPostQueueEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserPostQueueRepository extends JpaRepository<UserPostQueueEntity, Long> {
+
+    void deleteAllByUserIdAndAuthorId(Long userId, Long targetId);
+}

--- a/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueCommandRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueCommandRepository.java
@@ -1,0 +1,9 @@
+package fastcampus.feed.post.repository.post_queue;
+
+import fastcampus.feed.post.repository.entity.post.PostEntity;
+
+public interface UserPostQueueCommandRepository {
+    void publishPost(PostEntity postEntity); // 내 팔로워들한테 보여주는 메서드
+    void saveFollowPost(Long userId, Long targetId); // 내가 팔로우하는 사람들의 피드를 보여주는 메서드
+    void deleteUnFollowPost(Long userId, Long targetId); // 내가 팔로우하는 사람들의 피드를 삭제하는 메서드
+}

--- a/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueCommandRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueCommandRepositoryImpl.java
@@ -1,0 +1,51 @@
+package fastcampus.feed.post.repository.post_queue;
+
+import fastcampus.feed.post.repository.entity.post.PostEntity;
+import fastcampus.feed.post.repository.entity.post.UserPostQueueEntity;
+import fastcampus.feed.post.repository.jpa.JpaPostRepository;
+import fastcampus.feed.post.repository.jpa.JpaUserPostQueueRepository;
+import fastcampus.feed.user.repository.entity.UserEntity;
+import fastcampus.feed.user.repository.jpa.JpaFollowRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Repository
+public class UserPostQueueCommandRepositoryImpl implements UserPostQueueCommandRepository{
+
+    private final JpaPostRepository jpaPostRepository;
+    private final JpaFollowRepository jpaFollowRepository;
+    private final JpaUserPostQueueRepository jpaUserPostQueueRepository;
+
+    @Transactional
+    @Override// 나를 팔로우하는 사람들에게 피드를 보여주는 메서드
+    public void publishPost(PostEntity postEntity) {
+        UserEntity userEntity = postEntity.getAuthor();
+        List<Long> followerIds = jpaFollowRepository.findFollowers(userEntity.getId());
+
+        List<UserPostQueueEntity> userPostQueueEntityList = followerIds.stream()
+                        .map(userId -> new UserPostQueueEntity(userId, postEntity.getId(), userEntity.getId()))
+                        .toList();
+
+        jpaUserPostQueueRepository.saveAll(userPostQueueEntityList);
+    }
+
+    @Transactional
+    @Override// 내가 팔로우하는 사람들의 피드를 보여주는 메서드
+    public void saveFollowPost(Long userId, Long targetId) {
+        List<Long> postIds = jpaPostRepository.findAllPostIdsByAuthorId(targetId);
+        List<UserPostQueueEntity> userPostQueueEntityList = postIds.stream()
+                .map(postId -> new UserPostQueueEntity(userId, postId, targetId))
+                .toList();
+
+        jpaUserPostQueueRepository.saveAll(userPostQueueEntityList);
+    }
+
+    @Transactional
+    @Override// 언팔로우 시 팔로우한 사람의 피드를 삭제하는 메서드
+    public void deleteUnFollowPost(Long userId, Long targetId) {
+        jpaUserPostQueueRepository.deleteAllByUserIdAndAuthorId(userId, targetId);
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueQueryRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueQueryRepository.java
@@ -1,0 +1,9 @@
+package fastcampus.feed.post.repository.post_queue;
+
+import fastcampus.feed.post.controller.dto.GetPostContentResponseDto;
+import java.util.List;
+
+public interface UserPostQueueQueryRepository {
+    List<GetPostContentResponseDto> getContentResponse(Long userId, Long lastPostId);
+
+}

--- a/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueQueryRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/post_queue/UserPostQueueQueryRepositoryImpl.java
@@ -1,0 +1,77 @@
+package fastcampus.feed.post.repository.post_queue;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import fastcampus.feed.post.controller.dto.GetPostContentResponseDto;
+import fastcampus.feed.post.repository.entity.like.LikeTarget;
+import fastcampus.feed.post.repository.entity.like.QLikeEntity;
+import fastcampus.feed.post.repository.entity.post.QPostEntity;
+import fastcampus.feed.post.repository.entity.post.QUserPostQueueEntity;
+import fastcampus.feed.user.repository.entity.QUserEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserPostQueueQueryRepositoryImpl implements UserPostQueueQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private static final QUserPostQueueEntity userPostQueueEntity = QUserPostQueueEntity.userPostQueueEntity;
+    private static final QPostEntity postEntity = QPostEntity.postEntity;
+    private static final QUserEntity userEntity = QUserEntity.userEntity;
+    private static final QLikeEntity likeEntity = QLikeEntity.likeEntity;
+
+
+    @Override
+    public List<GetPostContentResponseDto> getContentResponse(Long userId, Long lastPostId) {
+        return queryFactory
+                .select(
+                        Projections.fields(
+                                GetPostContentResponseDto.class,
+                                postEntity.id.as("id"),
+                                postEntity.content.as("content"),
+                                userEntity.id.as("userId"),
+                                userEntity.name.as("userName"),
+                                userEntity.profileImageUrl.as("userProfileImage"),
+                                postEntity.regDt.as("createdAt"),
+                                postEntity.updDt.as("updatedAt"),
+                                postEntity.commentCount.as("commentCount"),
+                                postEntity.likeCount.as("likeCount"),
+                                likeEntity.isNotNull().as("isLikedByMe")
+                        )
+                )
+                .from(userPostQueueEntity)
+                .join(postEntity).on(userPostQueueEntity.postId.eq(postEntity.id))
+                .join(userEntity).on(userPostQueueEntity.authorId.eq(userEntity.id))
+                .leftJoin(likeEntity).on(hasLike(userId))
+                .where(
+                        userPostQueueEntity.userId.eq(userId),
+                        hasLastData(lastPostId)
+                )
+                .orderBy(userPostQueueEntity.postId.desc())
+                .limit(20)
+                .fetch();
+    }
+
+    private BooleanExpression hasLastData(Long lastId) {
+        if (lastId == null) {
+            return null;
+        }
+
+        return postEntity.id.lt(lastId);
+    }
+
+    private BooleanExpression hasLike(Long userId) {
+        if (userId == null) {
+            return null;
+        }
+
+        return postEntity.id
+                .eq(likeEntity.likeIdEntity.targetId)
+                .and(likeEntity.likeIdEntity.targetType.eq(LikeTarget.valueOf("POST")))
+                .and(likeEntity.likeIdEntity.userId.eq(userId));
+    }
+
+}

--- a/src/main/java/fastcampus/feed/post/service/CommentService.java
+++ b/src/main/java/fastcampus/feed/post/service/CommentService.java
@@ -10,10 +10,12 @@ import fastcampus.feed.post.service.dto.LikeCommentRequestDto;
 import fastcampus.feed.post.service.dto.UpdateCommentRequestDto;
 import fastcampus.feed.user.domain.User;
 import fastcampus.feed.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class CommentService {
 
     private final UserService userService;
@@ -21,13 +23,6 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
 
-    public CommentService(CommentRepository commentRepository, UserService userService,
-            LikeRepository likeRepository, PostService postService) {
-        this.commentRepository = commentRepository;
-        this.userService = userService;
-        this.likeRepository = likeRepository;
-        this.postService = postService;
-    }
     @Transactional
     public Comment createComment(CreateCommentRequestDto dto) {
         Post post = postService.getPost(dto.postId());

--- a/src/main/java/fastcampus/feed/user/repository/FollowRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/user/repository/FollowRepositoryImpl.java
@@ -1,5 +1,6 @@
 package fastcampus.feed.user.repository;
 
+import fastcampus.feed.post.repository.post_queue.UserPostQueueCommandRepository;
 import fastcampus.feed.user.domain.User;
 import fastcampus.feed.user.repository.entity.FollowEntity;
 import fastcampus.feed.user.repository.entity.FollowIdEntity;
@@ -17,6 +18,7 @@ public class FollowRepositoryImpl implements FollowRepository {
 
     private final JpaFollowRepository jpaFollowRepository;
     private final JpaUserRepository jpaUserRepository;
+    private final UserPostQueueCommandRepository userPostQueueCommandRepository;
 
 
     @Override
@@ -31,6 +33,7 @@ public class FollowRepositoryImpl implements FollowRepository {
         FollowEntity followEntity = new FollowEntity(user.getId(), targetUser.getId());
         jpaFollowRepository.save(followEntity);
         jpaUserRepository.saveAll(List.of(new UserEntity(user), new UserEntity(targetUser)));
+        userPostQueueCommandRepository.saveFollowPost(user.getId(), targetUser.getId());
     }
 
     @Override
@@ -38,5 +41,6 @@ public class FollowRepositoryImpl implements FollowRepository {
         FollowIdEntity followIdEntity = new FollowIdEntity(user.getId(), targetUser.getId());
         jpaFollowRepository.deleteById(followIdEntity);
         jpaUserRepository.saveAll(List.of(new UserEntity(user), new UserEntity(targetUser)));
+        userPostQueueCommandRepository.deleteUnFollowPost(user.getId(), targetUser.getId());
     }
 }

--- a/src/main/java/fastcampus/feed/user/repository/jpa/JpaFollowRepository.java
+++ b/src/main/java/fastcampus/feed/user/repository/jpa/JpaFollowRepository.java
@@ -2,8 +2,12 @@ package fastcampus.feed.user.repository.jpa;
 
 import fastcampus.feed.user.repository.entity.FollowEntity;
 import fastcampus.feed.user.repository.entity.FollowIdEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaFollowRepository extends JpaRepository<FollowEntity, FollowIdEntity> {
 
+    @Query("SELECT f.followingId FROM FollowEntity f WHERE f.followerId = :userId")
+    List<Long> findFollowers(Long userId);
 }

--- a/src/test/java/fastcampus/feed/fake/FakeObjectFactory.java
+++ b/src/test/java/fastcampus/feed/fake/FakeObjectFactory.java
@@ -31,8 +31,8 @@ public class FakeObjectFactory {
             fakeUserRelationRepository, userService);
     private static final PostService postService = new PostService(fakePostRepository, userService,
             fakeLikeRepository);
-    private static final CommentService commentService = new CommentService(fakeCommentRepository,
-            userService, fakeLikeRepository, postService);
+    private static final CommentService commentService = new CommentService(userService, postService,fakeCommentRepository,
+            fakeLikeRepository);
 
     public static UserService getUserService() {
         return userService;


### PR DESCRIPTION
PostQueue를 활용하여 성능 최적화


1. 나를 팔로우하는 사람들의 PostQueue에 내가 Post 작성 시 추가

2. 내가 팔로우하는 사람들의 Feed 저장

3. unfollow시 피드 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 사용자 피드 기능 추가
	- 게시물에 댓글 수 추적 기능 도입
	- 사용자 포스트 큐 시스템 구현

- **개선 사항**
	- SQL 쿼리 모니터링을 위한 의존성 추가
	- 팔로우/언팔로우 시 포스트 큐 관리 기능 강화

- **버그 수정**
	- 좋아요 대상 필드 이름 수정

이번 릴리즈는 소셜 미디어 피드 기능을 강화하고 사용자 경험을 개선하는 데 중점을 두었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->