### PR TITLE
Feat: Comment 조회 API

### DIFF
--- a/src/main/java/fastcampus/feed/post/controller/CommentController.java
+++ b/src/main/java/fastcampus/feed/post/controller/CommentController.java
@@ -1,11 +1,15 @@
 package fastcampus.feed.post.controller;
 
 import fastcampus.feed.common.controller.Response;
+import fastcampus.feed.post.controller.dto.GetCommentContentResponseDto;
+import fastcampus.feed.post.repository.interfaces.CommentQueryRepository;
 import fastcampus.feed.post.service.CommentService;
 import fastcampus.feed.post.service.dto.CreateCommentRequestDto;
 import fastcampus.feed.post.service.dto.LikeCommentRequestDto;
 import fastcampus.feed.post.service.dto.UpdateCommentRequestDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentQueryRepository commentQueryRepository;
 
     @PostMapping
     public Response<Long> createComment(@RequestBody CreateCommentRequestDto dto){
@@ -37,4 +42,8 @@ public class CommentController {
         return Response.ok(null);
     }
 
+    @GetMapping("/post/{postId}")
+    public Response<List<GetCommentContentResponseDto>> getCommentList(@PathVariable Long postId, Long userId, Long lastContentId){
+        return Response.ok(commentQueryRepository.getCommentList(postId, userId, lastContentId));
+    }
 }

--- a/src/main/java/fastcampus/feed/post/controller/dto/GetCommentContentResponseDto.java
+++ b/src/main/java/fastcampus/feed/post/controller/dto/GetCommentContentResponseDto.java
@@ -1,0 +1,16 @@
+package fastcampus.feed.post.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetCommentContentResponseDto extends GetContentResponseDto{
+
+}

--- a/src/main/java/fastcampus/feed/post/controller/dto/GetContentResponseDto.java
+++ b/src/main/java/fastcampus/feed/post/controller/dto/GetContentResponseDto.java
@@ -12,7 +12,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetContentResponseDto {
+public abstract class GetContentResponseDto {
 
     private Long id;
     private String content;

--- a/src/main/java/fastcampus/feed/post/repository/CommentQueryRepositoryImpl.java
+++ b/src/main/java/fastcampus/feed/post/repository/CommentQueryRepositoryImpl.java
@@ -1,0 +1,71 @@
+package fastcampus.feed.post.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import fastcampus.feed.post.controller.dto.GetCommentContentResponseDto;
+import fastcampus.feed.post.repository.entity.comment.QCommentEntity;
+import fastcampus.feed.post.repository.entity.like.LikeTarget;
+import fastcampus.feed.post.repository.entity.like.QLikeEntity;
+import fastcampus.feed.post.repository.interfaces.CommentQueryRepository;
+import fastcampus.feed.user.repository.entity.QUserEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQueryRepositoryImpl implements CommentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QCommentEntity commentEntity = QCommentEntity.commentEntity;
+    private final QUserEntity userEntity = QUserEntity.userEntity;
+    private final QLikeEntity likeEntity = QLikeEntity.likeEntity;
+
+    @Override
+    public List<GetCommentContentResponseDto> getCommentList(Long postId,Long userId, Long lastContentId) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                GetCommentContentResponseDto.class,
+                                commentEntity.id.as("id"),
+                                commentEntity.content.as("content"),
+                                userEntity.id.as("userId"),
+                                userEntity.name.as("userName"),
+                                userEntity.profileImageUrl.as("profileImageUrl"),
+                                commentEntity.likeCount.as("likeCount"),
+                                commentEntity.regDt.as("createdAt"),
+                                commentEntity.updDt.as("updatedAt"),
+                                likeEntity.isNotNull().as("isLikedByMe")
+                        )
+                )
+                .from(commentEntity)
+                .join(userEntity).on(commentEntity.author.id.eq(userEntity.id))
+                .leftJoin(likeEntity).on(hasLike(userId))
+                .where(commentEntity.post.id.eq(postId),
+                        hasLastData(lastContentId)
+                )
+                .orderBy(commentEntity.id.desc())
+                .limit(10)
+                .fetch();
+    }
+
+    private BooleanExpression hasLastData(Long lastContentId) {
+        if (lastContentId == null) {
+            return null;
+        }
+        return commentEntity.id.lt(lastContentId);
+    }
+
+    private BooleanExpression hasLike(Long userId) {
+        if (userId == null) {
+            return null;
+        }
+
+        return commentEntity.id
+                .eq(likeEntity.likeIdEntity.targetId)
+                .and(likeEntity.likeIdEntity.userId.eq(userId))
+                .and(likeEntity.likeIdEntity.targetType.eq(
+                        LikeTarget.valueOf(LikeTarget.COMMENT.name())));
+    }
+}

--- a/src/main/java/fastcampus/feed/post/repository/interfaces/CommentQueryRepository.java
+++ b/src/main/java/fastcampus/feed/post/repository/interfaces/CommentQueryRepository.java
@@ -1,0 +1,11 @@
+package fastcampus.feed.post.repository.interfaces;
+
+import fastcampus.feed.post.controller.dto.GetCommentContentResponseDto;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentQueryRepository {
+
+    List<GetCommentContentResponseDto> getCommentList(Long postId,Long userId, Long lastContentId);
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:~/feed
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false


### PR DESCRIPTION
Comment 조회 API 
Querydsl로 동적 생성 구현
lastContentId와 userId를 전달 받아 반환 개수 조절

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게시물에 대한 댓글 목록을 조회하는 기능 추가
	- 댓글 조회 시 사용자 정보와 좋아요 상태 포함

- **개선 사항**
	- 댓글 조회를 위한 새로운 데이터 전송 객체(DTO) 생성
	- 페이징 기능을 통해 최신 10개의 댓글 로드

- **기술적 변경**
	- 테스트 환경을 위한 H2 데이터베이스 설정 추가
	- 데이터 조회 방식 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->